### PR TITLE
Re-enable RCP integration tests

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -17,5 +17,4 @@ jobs:
         distribution: 'adopt'
         java-version: '11'
     - name: Build with Maven
-      run: mvn clean verify --file pom.xml
-      
+      run: mvn clean verify -Dskip.ui-tests=true

--- a/pom.xml
+++ b/pom.xml
@@ -11,9 +11,13 @@
 		     - and here: -->
 		<tycho.version>2.6.0</tycho.version>
 
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<!-- To skip integration tests use: mvn verify -Dskip.ui-tests=true -->
+		<skip.ui-tests>false</skip.ui-tests>
+
 		<!-- Skip the deployment here, submodules can override this property -->
 		<!--maven.deploy.skip>true</maven.deploy.skip-->
+
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
 	<build>

--- a/tests/com.vogella.tycho.rcp.it.tests/pom.xml
+++ b/tests/com.vogella.tycho.rcp.it.tests/pom.xml
@@ -5,9 +5,9 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.vogella.tycho</groupId>
-		<artifactId>tests</artifactId>
+		<artifactId>com.vogella.tycho.tests</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>../pom.tycho</relativePath>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>com.vogella.tycho.rcp.it.tests</artifactId>
@@ -21,6 +21,7 @@
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tycho.version}</version>
 				<configuration>
+					<skipTests>${skip.ui-tests}</skipTests>
 					<useUIHarness>true</useUIHarness>
 					<useUIThread>false</useUIThread>
 					<product>com.vogella.tycho.rcp.product</product>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -15,6 +15,6 @@
     <modules>
         <module>com.vogella.tycho.plugin1.tests</module>
         <module>com.vogella.tycho.rcp.tests</module>
-        <!--	<module>com.vogella.tycho.rcp.it.tests</module> -->
+        <module>com.vogella.tycho.rcp.it.tests</module>
     </modules>
 </project>


### PR DESCRIPTION
Re-enable RCP integration tests provided by the [`com.vogella.tycho.rcp.it.tests`](https://github.com/vogellacompany/tycho-example/tree/master/tests/com.vogella.tycho.rcp.it.tests) fragment.