### PR TITLE
Update Eclipse Tycho from 2.3 to 2.6

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
 	<extension>
 		<groupId>org.eclipse.tycho.extras</groupId>
 		<artifactId>tycho-pomless</artifactId>
-		<version>2.3.0</version>
+		<version>2.6.0</version>
 	</extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,16 @@
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<properties>
-		<tycho.version>2.3.0</tycho.version>
+
+		<!-- Tycho version (<https://github.com/eclipse/tycho/blob/master/RELEASE_NOTES.md>) specified in:
+		     - .mvn/extensions.xml
+		     - and here: -->
+		<tycho.version>2.6.0</tycho.version>
+
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<!-- Skip the deployment here, submodules can override this property -->
 		<!--maven.deploy.skip>true</maven.deploy.skip-->
 	</properties>
-
 
 	<build>
 		<pluginManagement>


### PR DESCRIPTION
Update Eclipse Tycho from 2.3 to 2.6

See [Eclipse Tycho 2.3.0 release notes](https://github.com/eclipse/tycho/blob/master/RELEASE_NOTES.md#260).