### PR TITLE
Fix and re-enable plugin1 tests

### DIFF
--- a/tests/com.vogella.tycho.plugin1.tests/META-INF/MANIFEST.MF
+++ b/tests/com.vogella.tycho.plugin1.tests/META-INF/MANIFEST.MF
@@ -6,10 +6,7 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: VOGELLA
 Fragment-Host: com.vogella.tycho.plugin1;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.junit.jupiter.engine;bundle-version="5.7.0",
- org.mockito.junit-jupiter;bundle-version="3.7.7",
- org.mockito.mockito-core;bundle-version="3.7.7",
- org.junit.platform.engine;bundle-version="1.7.0",
- org.eclipse.jdt.junit.runtime;bundle-version="3.5.400",
- org.junit;bundle-version="4.13.0"
-Import-Package: org.junit.jupiter.api;version="5.7.0"
+Require-Bundle: org.mockito.junit-jupiter;bundle-version="3.7.7",
+ org.mockito.mockito-core;bundle-version="3.7.7"
+Import-Package: org.junit;version="4.13.0",
+ org.junit.jupiter.api;version="5.7.0"

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -13,7 +13,7 @@
     </parent>
 
     <modules>
-        <!--	   <module>com.vogella.tycho.plugin1.tests</module> -->
+        <module>com.vogella.tycho.plugin1.tests</module>
         <module>com.vogella.tycho.rcp.tests</module>
         <!--	<module>com.vogella.tycho.rcp.it.tests</module> -->
     </modules>


### PR DESCRIPTION
Fix and re-enable plugin1 tests: [`com.vogella.tycho.plugin1.tests`](https://github.com/vogellacompany/tycho-example/tree/master/tests/com.vogella.tycho.plugin1.tests)

See https://wiki.eclipse.org/Tycho/How_Tos/JUnit5