### PR TITLE
Update to the latest Eclipse release 2022-09 (4.25) and to Tycho 3.0.0

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v2
       with:
         distribution: 'adopt'
-        java-version: '11'
+        java-version: '17'
     - name: Build with Maven
       run: mvn clean verify -Dskip.ui-tests=true

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
 	<extension>
 		<groupId>org.eclipse.tycho</groupId>
 		<artifactId>tycho-build</artifactId>
-		<version>2.7.4</version>
+		<version>3.0.0</version>
 	</extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 		<!-- Tycho version (<https://github.com/eclipse/tycho/blob/master/RELEASE_NOTES.md>) specified in:
 		     - .mvn/extensions.xml
 		     - and here: -->
-		<tycho.version>2.7.4</tycho.version>
+		<tycho.version>3.0.0</tycho.version>
 
 		<!-- To skip integration tests use: mvn verify -Dskip.ui-tests=true -->
 		<skip.ui-tests>false</skip.ui-tests>
@@ -38,7 +38,7 @@
 				<version>${tycho.version}</version>
 				<dependencies>
 					<dependency>
-						<groupId>org.eclipse.tycho.extras</groupId>
+						<groupId>org.eclipse.tycho</groupId>
 						<artifactId>tycho-buildtimestamp-jgit</artifactId>
 						<version>${tycho.version}</version>
 					</dependency>

--- a/releng/target-platform/target-platform.target
+++ b/releng/target-platform/target-platform.target
@@ -23,18 +23,18 @@
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/releases/latest"/>
-			<unit id="org.junit.jupiter.api" version="0.0.0"/>
-			<unit id="org.junit.jupiter.engine" version="0.0.0"/>
+			<unit id="junit-jupiter-api" version="0.0.0"/>
+			<unit id="junit-jupiter-engine" version="0.0.0"/>
 			<unit id="org.eclipse.jdt.junit5.runtime" version="0.0.0"/>
 			<unit id="org.junit" version="0.0.0"/>
 			<unit id="org.hamcrest.core" version="0.0.0"/>
 		</location>
-	
-		
+
+
 		<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
 
 			<feature id="test.libraries.feature" label="Test library feature" version="1.0.0.qualifier">
-   
+
 			</feature>
 			<dependencies>
 				<dependency>
@@ -60,7 +60,7 @@
     			   <artifactId>objenesis</artifactId>
     				<version>3.2</version>
 				</dependency>
-				
+
 			</dependencies>
 		</location>
 	</locations>


### PR DESCRIPTION
Using the Eclipse platform **2022-09 (4.25) and JUnit 5 tests requires** that in the target platform installable units starting with **`org.junit.jupiter.`** have **to be renamed to** ones starting with **`junit-jupiter-`**. This would also apply to existing JUnit Jupiter references in `Require-Bundle` statements and of features, which is not the case here, as `Import-Package` statements are used here as recommended.

This in turn requires **Tycho** to be updated to **3.0.0** in order to still recognize JUnit 5 tests by the JUnit Jupiter bundles that have been renamed in the Eclipse 2022-09 (4.25) release. Otherwise, the build would fail with the error message _No tests found_.

Tycho 3.0.0, in turn again, requires Maven to be run with **Java 17** or higher and the group ID of `tycho-buildtimestamp-jgit` to be changed from `org.eclipse.tycho.extras` to `org.eclipse.tycho`.

See also: [Tycho migration guide 2.x -> 3.x](https://github.com/eclipse-tycho/tycho/blob/master/RELEASE_NOTES.md#migration-guide-2x---3x)